### PR TITLE
TokensRegexAnnotator property splitting fix

### DIFF
--- a/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
+++ b/src/edu/stanford/nlp/pipeline/TokensRegexAnnotator.java
@@ -63,7 +63,7 @@ public class TokensRegexAnnotator implements Annotator {
 
   public TokensRegexAnnotator(String name, Properties props) {
     String prefix = (name == null)? "": name + '.';
-    String[] files  = PropertiesUtils.getStringArray(props, prefix + "rules");
+    String[] files  = StringUtils.split(props.getProperty(prefix + "rules"), "\\s*[,;]\\s*")
     if (files == null || files.length == 0) {
       throw new RuntimeException("No rules specified for TokensRegexAnnotator " + name + ", check " + prefix + "rules property");
     }


### PR DESCRIPTION
Fix for #311.

To split the rules property for TokensRegexAnnotator into an array we now use StringUtils.split (exactly as done in TimeAnnotator) instead of StringUtils.decodeArray which fails under windows.